### PR TITLE
Fix ZBD Trigger.dev integration task API

### DIFF
--- a/integrations/zbd/src/index.ts
+++ b/integrations/zbd/src/index.ts
@@ -1,94 +1,62 @@
-import type { IntegrationClient, TriggerIntegration } from "@trigger.dev/sdk";
-import { ZBD as ZBDClient } from "@zbd/node";
-
-import type { AuthenticatedTask } from "@trigger.dev/sdk";
-
-type SendLNAddressPaymentData = Parameters<InstanceType<typeof ZBDClient>["sendLightningAddressPayment"]>[0];
-
-type SendLNAddressPaymentResponse = {
-  success: boolean,
-  message: string,
-  data: {
-    id: string,                    // payment id
-    fee: string,                   // fee in satoshis (0 if no fee)
-    unit: string,                  // unit of transaction (satoshis)
-    amount: string,                // amount in satoshis
-    status: string,                // status of transaction
-    invoice: string,               // lightning network invoice/charge
-    walletId: string,              // id of wallet performing transaction
-    createdAt: string,             // timestamp of transaction creation
-    transactionId: string,         // transaction id
-    comment: string | null,        // comment attached to transaction
-    preimage: string | null,       // lightning preimage
-    internalId: string | null,     // internal user-entered metadata
-    callbackUrl: string | null,    // callback url to receive updates
-    processedAt: string | null,    // timestamp of transaction settlement
-  },
-};
-
-export const sendLightningAddressPayment: AuthenticatedTask<
-  InstanceType<typeof ZBDClient>,
-  SendLNAddressPaymentData,
-  SendLNAddressPaymentResponse
-> = {
-  run: async (params, client) => {
-    return client.sendLightningAddressPayment(params) as Promise<SendLNAddressPaymentResponse>;
-  },
-  init: (params) => {
-    return {
-      name: "Send Lightning Payment",
-      params,
-      icon: "zbd",
-      properties: [
-        {
-          label: "Lightning Address",
-          text: params.lnAddress,
-        },
-        {
-          label: "Amount",
-          text: params.amount,
-        },
-        {
-          label: "Comment",
-          text: params.comment,
-        },
-      ],
-      retry: {
-        limit: 8,
-        factor: 1.8,
-        minTimeoutInMs: 500,
-        maxTimeoutInMs: 30000,
-        randomize: true,
-      },
-    };
-  },
-};
-
-const tasks = {
-  sendLightningAddressPayment,
-};
+import {
+  ConnectionAuth,
+  IO,
+  IOTask,
+  IntegrationTaskKey,
+  Json,
+  RunTaskErrorCallback,
+  RunTaskOptions,
+  TriggerIntegration,
+  retry,
+} from "@trigger.dev/sdk";
+import { zbd as ZBDClient } from "@zbd/node";
+import type {
+  SendLightningAddressPaymentDataResponseType,
+  SendLightningAddressPaymentOptionsType,
+} from "@zbd/node/dist/types";
 
 export type ZBDIntegrationOptions = {
   id: string;
-  apiKey: string;
+  apiKey?: string;
+  apiBaseUrl?: string;
 };
 
-export class ZBD implements TriggerIntegration<IntegrationClient<ZBDClient, typeof tasks>> {
-  client: IntegrationClient<ZBDClient, typeof tasks>;
+export type ZBDRunTask = InstanceType<typeof ZBD>["runTask"];
+
+export class ZBD implements TriggerIntegration {
+  // @internal
+  private _options: ZBDIntegrationOptions;
+  // @internal
+  private _client?: ZBDClient;
+  // @internal
+  private _io?: IO;
+  // @internal
+  private _connectionKey?: string;
 
   constructor(private options: ZBDIntegrationOptions) {
     if (Object.keys(options).includes("apiKey") && !options.apiKey) {
       throw `Can't create ZBD integration (${options.id}) as apiKey was undefined`;
     }
 
-    this.client = {
-      tasks,
-      usesLocalAuth: true,
-      client: new ZBDClient(options.apiKey),
-      auth: {
-        apiKey: options.apiKey,
-      },
-    };
+    this._options = options;
+  }
+
+  get authSource() {
+    return "LOCAL" as const;
+  }
+
+  cloneForRun(io: IO, connectionKey: string, auth?: ConnectionAuth) {
+    const apiKey = this._options.apiKey ?? auth?.accessToken;
+
+    if (!apiKey) {
+      throw new Error(`Can't initialize ZBD integration (${this._options.id}) as apiKey was undefined`);
+    }
+
+    const zbd = new ZBD(this._options);
+    zbd._io = io;
+    zbd._connectionKey = connectionKey;
+    zbd._client = new ZBDClient(apiKey, this._options.apiBaseUrl);
+    return zbd;
   }
 
   get id() {
@@ -97,5 +65,71 @@ export class ZBD implements TriggerIntegration<IntegrationClient<ZBDClient, type
 
   get metadata() {
     return { id: "zbd", name: "ZBD" };
+  }
+
+  runTask<T, TResult extends Json<T> | void>(
+    key: IntegrationTaskKey,
+    callback: (client: ZBDClient, task: IOTask, io: IO) => Promise<TResult>,
+    options?: RunTaskOptions,
+    errorCallback?: RunTaskErrorCallback
+  ): Promise<TResult> {
+    if (!this._io) throw new Error("No IO");
+    if (!this._connectionKey) throw new Error("No connection key");
+
+    return this._io.runTask(
+      key,
+      (task, io) => {
+        if (!this._client) throw new Error("No client");
+        return callback(this._client, task, io);
+      },
+      {
+        icon: "zbd",
+        retry: retry.standardBackoff,
+        ...(options ?? {}),
+        connectionKey: this._connectionKey,
+      },
+      errorCallback
+    );
+  }
+
+  sendLightningAddressPayment(
+    key: IntegrationTaskKey,
+    params: SendLightningAddressPaymentOptionsType
+  ): Promise<SendLightningAddressPaymentDataResponseType> {
+    return this.runTask(
+      key,
+      async (client) => client.sendLightningAddressPayment(params),
+      {
+        name: "Send Lightning Address Payment",
+        params,
+        icon: "zbd",
+        properties: [
+          {
+            label: "Lightning Address",
+            text: params.lnAddress,
+          },
+          {
+            label: "Amount",
+            text: params.amount,
+          },
+          ...(params.comment
+            ? [
+                {
+                  label: "Comment",
+                  text: params.comment,
+                },
+              ]
+            : []),
+          ...(params.internalId
+            ? [
+                {
+                  label: "Internal ID",
+                  text: params.internalId,
+                },
+              ]
+            : []),
+        ],
+      }
+    );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,6 +636,25 @@ importers:
       tsup: 7.1.0_typescript@4.9.4
       typescript: 4.9.4
 
+  integrations/zbd:
+    specifiers:
+      '@trigger.dev/integration-kit': workspace:^2.0.12
+      '@trigger.dev/sdk': workspace:^2.0.12
+      '@trigger.dev/tsconfig': workspace:*
+      '@types/node': '18'
+      '@zbd/node': ^0.6.3
+      rimraf: ^3.0.2
+      tsup: ^6.5.0
+    dependencies:
+      '@trigger.dev/integration-kit': link:../../packages/integration-kit
+      '@trigger.dev/sdk': link:../../packages/trigger-sdk
+      '@zbd/node': 0.6.4
+    devDependencies:
+      '@trigger.dev/tsconfig': link:../../config-packages/tsconfig
+      '@types/node': 18.17.1
+      rimraf: 3.0.2
+      tsup: 6.6.3
+
   packages/astro:
     specifiers:
       '@trigger.dev/tsconfig': workspace:*
@@ -14924,6 +14943,13 @@ packages:
       tslib: 2.6.2
     dev: true
 
+  /@zbd/node/0.6.4:
+    resolution: {integrity: sha512-Dx+nYDlqo3EjbhvUrLgbdtYPQrdeI6yYq+SjJv+MumCOTO2BAZsJSqiS6nPLuqJK80pHch8vAtZKOkVeVduD1w==}
+    engines: {node: '>=14'}
+    dependencies:
+      node-fetch: 3.3.2
+    dev: false
+
   /@zxing/text-encoding/0.9.0:
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
     requiresBuild: true
@@ -25051,6 +25077,7 @@ packages:
   /node-domexception/1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
     dev: false
 
   /node-emoji/1.11.0:
@@ -25104,6 +25131,15 @@ packages:
 
   /node-fetch/3.3.0:
     resolution: {integrity: sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+    dev: false
+
+  /node-fetch/3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       data-uri-to-buffer: 4.0.1


### PR DESCRIPTION
Closes #2
/claim #2

## Summary
- Updates the existing ZBD integration to the current Trigger.dev integration shape.
- Uses the exported `zbd` client from `@zbd/node`.
- Adds `cloneForRun`, local auth handling, and a typed `sendLightningAddressPayment` task wrapper around `io.runTask`.

## Testing
- Installed dependencies with Node 18 and pnpm 7.18.1.
- Ran `pnpm --filter @trigger.dev/zbd build` successfully.

## Notes
The default Node on my machine is too new for this repo's pinned pnpm, so validation was done with Homebrew Node 18.